### PR TITLE
upgrade actions versions

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -41,12 +41,12 @@ jobs:
       - name: Install Dart Sass Embedded
         run: sudo snap install dart-sass-embedded
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo


### PR DESCRIPTION
> Node.js 20 actions are deprecated. The following actions are running on
> Node.js 20 and may not work as expected: actions/checkout@v3,
> actions/configure-pages@v3,
> actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02.
> Actions will be forced to run with Node.js 24 by default starting
> June 2nd, 2026. Please check if updated versions of these actions
> are available that support Node.js 24.